### PR TITLE
fix publish-to-pypi.yaml

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -1,9 +1,5 @@
 name: Publish Python distribution to PyPI
-on:
-  push:
-    branches:
-      - 'main'
-      - 'releases/**'
+on: push
 
 jobs:
   build:


### PR DESCRIPTION
* setting branch names breaks the pypi publishing steps