### PR TITLE
add update_footer()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "distrobuilder_menu"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
   { name="Stuart Cardall", email="developer@it-offshore.co.uk" },
 ]

--- a/src/distrobuilder_menu/config/app.py
+++ b/src/distrobuilder_menu/config/app.py
@@ -94,6 +94,6 @@ def get_args(argv=None):
                         help="regenerate custom templates")
     parser.add_argument("-v", "--version", action="version",
                         help="show dbmenu version",
-                        version='Distrobuilder Menu 0.2.3')
+                        version='Distrobuilder Menu 0.2.4')
 
     return parser.parse_args(argv)

--- a/src/distrobuilder_menu/menus/cloudinit.py
+++ b/src/distrobuilder_menu/menus/cloudinit.py
@@ -12,7 +12,7 @@ from distrobuilder_menu.config.user import Settings
 # singleton class shares user config between modules
 USER_CONFIG = Settings.instance()
 
-def merge_cloudinit(src_template=None, edit=True):
+def merge_cloudinit(src_template=None, edit=True, update_footer=True):
     """ Merges a cloud-init yaml template into a custom template via
         utils.yaml_add_content()
 
@@ -57,6 +57,11 @@ def merge_cloudinit(src_template=None, edit=True):
         # tidy up template
         utils.format_template(src_template)
 
+        # optionally update dbmenu footer (during ad hoc cloudinit config merges)
+        if update_footer:
+            utils.update_footer(src_template, 'cloudinit', cloudinit_file, subkey=node_section)
+
+        # optionally edit
         if edit:
             question = 'Edit merged template [Y/n]: ? '
             utils.edit_file(src_template, USER_CONFIG.console_editor, question=question)

--- a/src/distrobuilder_menu/menus/common.py
+++ b/src/distrobuilder_menu/menus/common.py
@@ -440,7 +440,9 @@ def generate_custom_template():
                                       )
         if cloud_choice.startswith('y') or cloud_choice.startswith('Y'):
             # tidies up template & optionally edits it
-            cloudinit_file = cloudinit.merge_cloudinit(dest_custom, edit=False)
+            cloudinit_file = cloudinit.merge_cloudinit(dest_custom, edit=False,
+                                                       update_footer=False
+                                                       )
         else:
             # tidy up template
             utils.format_template(dest_custom)

--- a/src/distrobuilder_menu/utils.py
+++ b/src/distrobuilder_menu/utils.py
@@ -615,3 +615,31 @@ def add_custom_footer(template_path, footer_data, msg=False):
     else:
         if msg:
             print(f"wrote dbmenu footer to {template_type} template: {template_name}")
+
+
+def update_footer(template_path, key, value, subkey=None):
+    """ Updates dbmenu footer key values
+
+        used to update the footer during ad hoc cloudinit additions to templates
+    Args:
+        template_path (str): path to template
+        key (str): footer key to update
+        value (_type_): value of the key to add / update
+    """
+    footer_str = '#dbmenu'
+    footer_data = find_regex(template_path, '#dbmenu.*$', substring=footer_str, json_dict=True)
+
+    if subkey:
+        # only cloudinit key can be None
+        if footer_data[key] is None:
+            cloudinit = {}
+            cloudinit[subkey] = value
+            footer_data[key] = cloudinit
+        else:
+            footer_data[key][subkey] = value
+    else:
+        footer_data[key] = value
+
+    # update template footer
+    remove_lines(template_path, footer_str)
+    write_footer(footer_data, template_path, f"\n{footer_str}")


### PR DESCRIPTION
* cloudinit configuration can be ad hoc merged into a template (& not necessarily during 'Generate Custom Template')

  adds `update_footer()` to update the cloudinit key in the `dbmenu` json footer (optionally used during `merge_cloudinit()` )

  `update_footer()` can also update other `json` keys but this is not currently needed (as only the cloudinit key can be `None`)