### PR TITLE
add version updater / improve Gethub class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "distrobuilder_menu"
-version = "0.2.4"
+version = "0.2.5"
 authors = [
   { name="Stuart Cardall", email="developer@it-offshore.co.uk" },
 ]

--- a/src/distrobuilder_menu/app.py
+++ b/src/distrobuilder_menu/app.py
@@ -84,6 +84,10 @@ def main():
         templates.regenerate_template(base_list)
         templates.regenerate_template(custom_list)
 
+    # -v menu option
+    if ARGS.version:
+        GETHUB.check_latest_release()
+
     # by default show the main menu & also show it after individual options run
     common.menu_default()
 

--- a/src/distrobuilder_menu/config/app.py
+++ b/src/distrobuilder_menu/config/app.py
@@ -92,8 +92,8 @@ def get_args(argv=None):
     parser.add_argument("-r", "--regenerate", default=False,
                         action="store_true",
                         help="regenerate custom templates")
-    parser.add_argument("-v", "--version", action="version",
-                        help="show dbmenu version",
-                        version='Distrobuilder Menu 0.2.4')
+    parser.add_argument("-v", "--version", default=False,
+                        action="store_true",
+                        help="show dbmenu version / update to latest release")
 
     return parser.parse_args(argv)

--- a/src/distrobuilder_menu/templates.py
+++ b/src/distrobuilder_menu/templates.py
@@ -126,7 +126,7 @@ def update_templates():
     """
     download_list = []
     # lxc/lxc-ci/images API endpoint
-    url = f"{GETHUB.api_contents}/images"
+    url = f"{GETHUB.api.contents}/images"
 
     # check the Github 'contents' API
     file_list = GETHUB.check_file_list(url)

--- a/src/distrobuilder_menu/utils.py
+++ b/src/distrobuilder_menu/utils.py
@@ -643,3 +643,31 @@ def update_footer(template_path, key, value, subkey=None):
     # update template footer
     remove_lines(template_path, footer_str)
     write_footer(footer_data, template_path, f"\n{footer_str}")
+
+
+def update_dbmenu(tag_name):
+    """ Updates dbmenu with:
+
+        pipx || pip install --force distrobuilder-menu=={tag_name}
+    """
+    binary = None
+    choice = get_input(f"\nUpdate dbmenu to {tag_name} with pipx? [Y/n] : ",
+                       accept_empty=True, default='Y'
+                      )
+    if choice.startswith('y') or choice.startswith('Y'):
+        binary = 'pipx'
+    else:
+        choice = get_input(f"Update dbmenu to {tag_name} with pip? [y/N] : ",
+                           accept_empty=True
+                          )
+        if choice.startswith('y') or choice.startswith('Y'):
+            binary = 'pip'
+
+    if binary:
+        try:
+            print('')
+            # run shell command from python displaying output
+            cmd = f"{binary} install --force distrobuilder-menu=={tag_name}"
+            subprocess.run(cmd, shell=True, check=True)
+        except subprocess.CalledProcessError:
+            die(1, f"\nError updating dbmenu with {binary}")


### PR DESCRIPTION
Switches from `argparse`'s builtin `--version` to some new functions:
* `check_latest_release()`
* `update_dbmenu()`

---

* adds a `dataclass`to [`Gethub`](https://github.com/itoffshore/distrobuilder-menu/blob/main/src/distrobuilder_menu/api/gethub.py) with useful public endpoints to makes the class more useful for querying Github's API for different repos

* adds optional app updates to the `-v` / `--version` options

  - uses `importlib.metadata` to detect the app version from `pyproject.toml`
  - by default `dbmenu` can be force updated with `pipx` with a **2nd option** to use `pip`

* changes the default option to `Y` for creating the `images` directory (that holds the `standard` templates)