### PR TITLE
improve packaging for Arch Linux / release 0.2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,16 @@ yq_check: true
 ---
 
 ### 📰 Template Examples
-* This repo's [`examples`](https://github.com/itoffshore/distrobuilder-menu/tree/main/examples) directory is also packaged under `site-packages` - e.g for `pipx` installs:
+* This repo's [`examples`](https://github.com/itoffshore/distrobuilder-menu/tree/main/examples) directory is also packaged under `site-packages`:
 
-   - `~/.local/pipx/venvs/distrobuilder-menu/lib/python3.11/site-packages/examples`
+   - e.g for `pipx` installs:
+
+   - `~/.local/pipx/venvs/distrobuilder-menu/lib/python3.11/site-packages/distrobuilder_menu/examples`
+
+   - e.g for installs from an Arch Linux package:
+
+   - `/usr/lib/python3.11/site-packages/distrobuilder_menu/examples`
+
 
 * These `examples` show how to create images for:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,11 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel.force-include]
-"examples" = "examples"
+"examples" = "distrobuilder_menu/examples"
 
 [project]
 name = "distrobuilder_menu"
-version = "0.2.6"
+version = "0.2.7"
 authors = [
   { name="Stuart Cardall", email="developer@it-offshore.co.uk" },
 ]


### PR DESCRIPTION
* fixes a packaging error when installing as a system module

  the `examples` directory is now correctly added within the app's `site-packages` directory & not outside.