### PR TITLE
Update PKGBUILD

### DIFF
--- a/aur/.SRCINFO
+++ b/aur/.SRCINFO
@@ -1,16 +1,16 @@
 pkgbase = distrobuilder-menu
 	pkgdesc = A python console frontend to Distrobuilder for building standard or customised LXD / LXC images
 	pkgver = 0.2.9
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/itoffshore/distrobuilder-menu
-	arch = x86_64
-	license = GPL
+	arch = any
+	license = MIT
 	makedepends = python-build
 	makedepends = python-installer
-	makedepends = python-wheel
-	depends = go-yq
+	makedepends = python-hatchling
 	depends = python-urllib3
 	depends = python-yaml
+	optdepends = go-yq: merge cloudinit configuration with yq
 	source = distrobuilder-menu-0.2.9.tar.gz::https://github.com/itoffshore/distrobuilder-menu/archive/0.2.9.tar.gz
 	md5sums = 35569f29d4b43f9d80ad358e715b6ec1
 

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Stuart Cardall <developer at it-offshore dot co dot uk>
 pkgname=distrobuilder-menu
 pkgver=0.2.9
-pkgrel=1
+pkgrel=2
 pkgdesc="A python console frontend to Distrobuilder for building standard or customised LXD / LXC images"
-arch=(x86_64)
+arch=(any)
 url="https://github.com/itoffshore/distrobuilder-menu"
-license=(GPL)
-depends=(go-yq python-urllib3 python-yaml)
-makedepends=(python-build python-installer python-wheel)
+license=(MIT)
+depends=(python-urllib3 python-yaml)
+makedepends=(python-build python-installer python-hatchling)
+optdepends=('go-yq: merge cloudinit configuration with yq')
 source=($pkgname-$pkgver.tar.gz::${url}/archive/${pkgver}.tar.gz)
 md5sums=('35569f29d4b43f9d80ad358e715b6ec1')
 
@@ -19,4 +20,5 @@ build() {
 package() {
     cd "$pkgname-$pkgver"
     python -m installer --destdir="$pkgdir" dist/*.whl
+    install -Dm644 LICENSE ${pkgdir}/usr/share/licenses/$pkgname/LICENSE
 }


### PR DESCRIPTION
Package contains no ELF files, so correct architecture.  
Set correct license & install it.  
go-yq seems like is not required, but for optional functionality.  
Update build deps.